### PR TITLE
Amelioration du display des erreurs.

### DIFF
--- a/mango.py
+++ b/mango.py
@@ -492,9 +492,7 @@ def print_error(line, rule, strings):
     if not strings["RESET"]:
         rule = [sub('\33\\[[0-9;]+m', '', rule[0]), sub('\33\\[[0-9;]+m', '', rule[1] or '')]
 
-    print(f"{color}{strings['BOLD']}{line[0]}", end="")
-    if int(line[1]) > 1:
-        print(f" at line {line[1]}", end="")
+    print(f"{color}{strings['BOLD']}{line[0]}:{line[1]}", end="")
     print(f"\n{line[2][1:]} {line[3]}: {color}{rule[0]}{strings['RESET']}")
     if rule[1]:
         print(f"{rule[1]}")


### PR DESCRIPTION
Permet d’accéder directement a la ligne contenant l'erreur avec un CTRL + clic.

**Ancienne version :**
![image](https://github.com/Clement-Z4RM/Mango/assets/100469363/10c7ad89-fbdb-4a03-a3d7-eaf479bf1081)

**Nouvelle version :**
![image](https://github.com/Clement-Z4RM/Mango/assets/100469363/907882b4-175d-43f2-9f37-a4af6562d6b7)
