### PR TITLE
fix(print_error): format compliant to vscode link (ctrl + click)

### DIFF
--- a/mango.py
+++ b/mango.py
@@ -493,8 +493,7 @@ def print_error(line, rule, strings):
         rule = [sub('\33\\[[0-9;]+m', '', rule[0]), sub('\33\\[[0-9;]+m', '', rule[1] or '')]
 
     print(f"{color}{strings['BOLD']}{line[0]}", end="")
-    if int(line[1]) > 1:
-        print(f" at line {line[1]}", end="")
+    print(f":{line[1]}", end="")
     print(f"\n{line[2][1:]} {line[3]}: {color}{rule[0]}{strings['RESET']}")
     if rule[1]:
         print(f"{rule[1]}")


### PR DESCRIPTION
Basically, when you use VS Code with built-in terminal, you can use `Ctrl + Click` for VS Code to send you to the exact line mentioned.
This is useful when correcting coding style errors, because you can save time by not having to search through files.

- Changed formatting from `<file> at line <line>` to `<file>:<line>`.
- Removed the test for `line > 1` because the line is required for link to work.

This sort of improved readability of the output as it's not cluttered by useless keyword, also making it more functional.